### PR TITLE
Master af up

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Available variables are listed below, along with default values:
 
     powerline_default_top_theme: powerline
     powerline_shell_vcs_branch: true
-    powerline_users:
-      - vagrant
+    powerline_home_dirs:
+      - /etc/skel
+      - /root
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 powerline_default_top_theme: powerline
 powerline_shell_vcs_branch: true
-powerline_users:
-  - vagrant
+powerline_home_dirs:
+  - /root
+  - /etc/skel

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,7 @@ galaxy_info:
   - name: Fedora
     versions:
     - 23
+    - 24
   categories:
   - system
 dependencies: []

--- a/tasks/install-dnf.yml
+++ b/tasks/install-dnf.yml
@@ -9,3 +9,13 @@
     - powerline
     - powerline-docs
   become: yes
+
+- name: Check if tmux is installed
+  command: which tmux
+  become: yes
+  register: check_tmux
+
+- name: Install package powerline-tmux if tmux is installed
+  dnf: name="tmux-powerline" state=present
+  become: yes
+  when: check_tmux.rc == 0

--- a/tasks/install-dnf.yml
+++ b/tasks/install-dnf.yml
@@ -19,3 +19,13 @@
   dnf: name="tmux-powerline" state=present
   become: yes
   when: check_tmux.rc == 0
+
+- name: Check if vim is installed
+  command: which vim
+  become: yes
+  register: check_vim
+
+- name: Install package vim-powerline if vim is installed
+  dnf: name="vim-powerline" state=present
+  become: yes
+  when: check_vim.rc == 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,3 +57,23 @@
   become: yes
   with_items: "{{ powerline_home_dirs }}"
   when: check_tmux_conf.stat.exists == True
+
+- name: "Check if vim-powerline is installed"
+  stat: path="/usr/share/vim/vimfiles/plugin/powerline.vim"
+  register: check_vim_powerline
+
+- name: "Enable powerline for vim"
+  blockinfile:
+    dest: "{{ item }}/.vimrc"
+    block: |
+      python3 from powerline.vim import setup as powerline_setup
+      python3 powerline_setup()
+      python3 del powerline_setup
+      set laststatus=2
+      set t_Co=256
+    create: yes
+    mode: 0644
+    marker: "\" {mark} ANSIBLE MANAGED BLOCK"
+  become: yes
+  with_items: "{{ powerline_home_dirs }}"
+  when: check_vim_powerline.stat.exists == True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,26 +11,13 @@
     state: absent
   become: yes
 
-- name: "ensure powerline script is installed"
+- name: "Install powerline script"
   template:
     src: powerline.sh.j2
     dest: /etc/bash_powerline.sh
   become: yes
 
-- name: "retrieve the list of home directories"
-  command: ls /home
-  register: home_dirs
-  changed_when: false
-
-- name: "ensure powerline is loaded for configured users"
-  lineinfile:
-    dest: "/home/{{ item }}/.bashrc"
-    line: "source /etc/bash_powerline.sh"
-  become: yes
-  when: "item in home_dirs.stdout_lines"
-  with_items: powerline_users
-
-- name: "ensure default top theme for powerline is configured"
+- name: "Configure top theme for powerline"
   lineinfile:
     dest: "{{ powerline_config_file }}"
     line: "\t\t\"default_top_theme\": \"{{ powerline_default_top_theme }}\","
@@ -38,13 +25,20 @@
     insertbefore: "term_truecolor"
   become: yes
 
-- name: "ensure powerline for shell is configured"
+- name: "Configure powerline for shell"
   template:
     src: powerline-shell.json.j2
     dest: "{{ powerline_themes_directory }}/shell/default.json"
   become: yes
 
-- name: "ensure powerline for tmux is configured"
+- name: "Enable powerline in bash shell"
+  lineinfile:
+    dest: "{{ item }}/.bashrc"
+    line: "source /etc/bash_powerline.sh"
+  become: yes
+  with_items: "{{ powerline_home_dirs }}"
+
+- name: "Configure powerline for tmux"
   template:
     src: powerline-tmux.json.j2
     dest: "{{ powerline_themes_directory }}/tmux/default.json"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,3 +43,17 @@
     src: powerline-tmux.json.j2
     dest: "{{ powerline_themes_directory }}/tmux/default.json"
   become: yes
+
+- name: "Check if tmux-powerline is installed"
+  stat: path="/usr/share/tmux/powerline.conf"
+  register: check_tmux_conf
+
+- name: "Enable powerline for tmux"
+  lineinfile:
+    dest: "{{ item }}/.tmux.conf"
+    line: "source /usr/share/tmux/powerline.conf"
+    create: yes
+    mode: 0644
+  become: yes
+  with_items: "{{ powerline_home_dirs }}"
+  when: check_tmux_conf.stat.exists == True


### PR DESCRIPTION
Hi Martin,
The 4 commits provide the following features:
- Users created with useradd automatically get powerline configured
- Domain users login for the first time automatically get powerline configured
- If tmux is installed powerline is enabled
- If vim is installed powerline is enabled

Changes you might consider as disadvantages:
- Variable powerline_users is replaced by variable powerline_home_dirs. This simplifies the implementation significantly. (Since everything works automagically even for users added in the future, the ansible user should be fine without settings this variable.)
- Vagrant user is not in defaults. Just add vagrant user's home directory to get the old behaviour back.
- Tested on Fedora 24 (vim-powerline uses python3, which breaks vim on distros with powerline using python2, could be fixed...)
